### PR TITLE
Fix careers form not saving to Supabase; update events calendar

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -103,8 +103,17 @@ alter table public.job_applications enable row level security;
 
 -- Applicants may submit, but nobody anonymous may read applications back.
 create policy "Enable insert for everyone" on public.job_applications
-  for insert to anon with check (true);
+  for insert to anon, authenticated with check (true);
 ```
+
+> **Do not chain `.select()` onto this insert.** Because there is deliberately no
+> SELECT policy, `.insert(...).select()` makes PostgREST run an
+> `INSERT ... RETURNING`, whose read-back RLS check fails and rolls the whole
+> statement back. Postgres reports it as
+> `new row violates row-level security policy for table "job_applications"`,
+> which reads like the *insert* was refused when only the *return* was — a
+> genuinely misleading error. `src/hooks/useJobApplication.ts` inserts without
+> `.select()` for this reason. The same applies to any other insert-only table.
 
 Read applications in the Supabase dashboard (Table Editor), or with SQL:
 

--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -3,28 +3,70 @@ import { waLink } from "../lib/whatsapp";
 
 const easeSoft = [0.25, 1, 0.5, 1] as const;
 
+type HZEEvent = {
+  title: string;
+  variant?: string;
+  dateISO: string;
+  category: string;
+  venue: string;
+  blurb: string;
+};
+
 // EDIT EVENTS HERE
-const EVENTS = [
+const EVENTS: HZEEvent[] = [
   {
-    title: "Book Swap",
-    dateISO: "2026-09-05",
-    category: "book-swap",
+    title: "Brew Better at Home",
+    variant: "Bring Your Gadgets Edition",
+    dateISO: "2026-08-29",
+    category: "brew-class",
     venue: "HZE Mbezi",
-    blurb: "Bring a book, take a book. Literary exchange over good coffee.",
+    blurb: "Bring your own kit — grinder, dripper, press — and we'll dial it in together.",
   },
   {
     title: "Brew Better at Home",
+    variant: "Class",
     dateISO: "2026-09-19",
     category: "brew-class",
     venue: "HZE Mbezi",
     blurb: "Pour-over, French press, and fixing your home brew — hands on.",
   },
   {
-    title: "Worship Experience",
-    dateISO: "2026-09-25",
-    category: "worship",
+    title: "Book Swap",
+    dateISO: "2026-09-26",
+    category: "book-swap",
     venue: "HZE Mbezi",
-    blurb: "An evening of worship, community, and kahawa.",
+    blurb: "Bring a book, take a book. Literary exchange over good coffee.",
+  },
+  {
+    title: "Brew Better at Home",
+    variant: "Cupping",
+    dateISO: "2026-10-14",
+    category: "brew-class",
+    venue: "HZE Mbezi",
+    blurb: "Taste side by side and learn how a coffee gets scored — slurp included.",
+  },
+  {
+    title: "Brew Better at Home",
+    variant: "Bring Your Gadgets Edition",
+    dateISO: "2026-11-20",
+    category: "brew-class",
+    venue: "HZE Mbezi",
+    blurb: "Bring your own kit — grinder, dripper, press — and we'll dial it in together.",
+  },
+  {
+    title: "Brew Better at Home",
+    variant: "Class",
+    dateISO: "2026-12-12",
+    category: "brew-class",
+    venue: "HZE Mbezi",
+    blurb: "Pour-over, French press, and fixing your home brew — hands on.",
+  },
+  {
+    title: "HZE Christmas Carols Party",
+    dateISO: "2026-12-19",
+    category: "carols",
+    venue: "HZE Mbezi",
+    blurb: "Carols, kahawa, and the whole HZE community closing out the year together.",
   },
 ];
 
@@ -37,6 +79,7 @@ const CATEGORIES: Record<
   "book-swap": { label: "Book Swap", emoji: "📚", color: "#2B7A6E", text: "#FFFFFF" },
   "brew-class": { label: "Brew Class", emoji: "☕", color: "#B37542", text: "#FFFFFF" },
   "games-night": { label: "Games Night", emoji: "🎲", color: "#D19D71", text: "#1C1408" },
+  carols: { label: "Carols Party", emoji: "🎄", color: "#B83528", text: "#FFFFFF" },
 };
 
 const RHYTHMS = [
@@ -50,6 +93,13 @@ const RHYTHMS = [
 const SWAHILI_MONTHS = [
   "Januari", "Februari", "Machi", "Aprili", "Mei", "Juni",
   "Julai", "Agosti", "Septemba", "Oktoba", "Novemba", "Desemba",
+];
+
+// Not a slice(0, 3) of the above — "Agosti" would abbreviate to "AGO", which
+// reads as English "ago" on a card about an upcoming event.
+const MONTH_ABBR = [
+  "Jan", "Feb", "Mac", "Apr", "Mei", "Jun",
+  "Jul", "Aug", "Sep", "Okt", "Nov", "Des",
 ];
 
 const daysUntil = (dateISO: string) => {
@@ -88,8 +138,7 @@ const EventsSection = () => {
   const upcoming = EVENTS
     .map((e) => ({ ...e, days: daysUntil(e.dateISO) }))
     .filter((e) => e.days >= 0)
-    .sort((a, b) => a.days - b.days)
-    .slice(0, 3);
+    .sort((a, b) => a.days - b.days);
 
   return (
     <section className="py-16 sm:py-24 bg-cream-aged relative" id="events">
@@ -136,7 +185,7 @@ const EventsSection = () => {
                         {d.getDate()}
                       </span>
                       <span className="font-sans text-xs uppercase tracking-widest mt-1">
-                        {SWAHILI_MONTHS[d.getMonth()].slice(0, 3)}
+                        {MONTH_ABBR[d.getMonth()]}
                       </span>
                     </div>
                     <div className="p-4 flex-1">
@@ -147,6 +196,11 @@ const EventsSection = () => {
                       >
                         {event.title}
                       </h3>
+                      {event.variant && (
+                        <p className="font-display font-light italic text-bronze-deep text-sm leading-tight mt-0.5">
+                          {event.variant}
+                        </p>
+                      )}
                       <p className="font-sans text-xs text-ink/50 mt-1">
                         {event.venue} · <span className="text-hze-red font-medium">{countdownLabel(event.days)}</span>
                       </p>
@@ -155,7 +209,7 @@ const EventsSection = () => {
                   <p className="px-4 pb-4 font-sans text-sm text-ink/70">{event.blurb}</p>
                   <div className="ticket-edge bg-cream-aged/60 mt-auto p-4 text-center">
                     <a
-                      href={waLink(`Nataka kujisajili: ${event.title} — ${formatDate(event.dateISO)}. Jina langu ni ___`)}
+                      href={waLink(`Nataka kujisajili: ${event.title}${event.variant ? ` (${event.variant})` : ""} — ${formatDate(event.dateISO)}. Jina langu ni ___`)}
                       target="_blank"
                       rel="noreferrer"
                       className="btn-press inline-flex items-center justify-center w-full px-5 py-3 bg-hze-teal text-white font-sans font-medium text-sm rounded-full hover:bg-[#236458] transition-colors min-h-[48px]"

--- a/src/hooks/useJobApplication.test.tsx
+++ b/src/hooks/useJobApplication.test.tsx
@@ -1,0 +1,90 @@
+import { createElement, type ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useJobApplication } from './useJobApplication';
+
+const insert = vi.fn();
+const from = vi.fn(() => ({ insert }));
+
+vi.mock('../lib/supabase', () => ({
+    supabase: {
+        get from() {
+            return from;
+        },
+    },
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+    const client = new QueryClient({
+        defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+    });
+    return createElement(QueryClientProvider, { client }, children);
+};
+
+const answers = {
+    full_name: 'Asha Mwinyi',
+    email: 'asha@example.com',
+    phone: '+255700000000',
+    area: 'Mbezi',
+    preferred_location: 'HZE Mbezi',
+    experience_level: '1-2 years',
+    start_date: 'Immediately',
+    notice_period: 'None',
+    salary: '600,000',
+};
+
+describe('useJobApplication', () => {
+    beforeEach(() => {
+        insert.mockReset();
+        from.mockClear();
+        insert.mockResolvedValue({ error: null });
+    });
+
+    it('inserts into job_applications and maps answers onto columns', async () => {
+        const { result } = renderHook(() => useJobApplication(), { wrapper });
+
+        result.current.mutate({ role: 'Barista', answers });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(from).toHaveBeenCalledWith('job_applications');
+
+        const [rows] = insert.mock.calls[0];
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            role: 'Barista',
+            full_name: 'Asha Mwinyi',
+            email: 'asha@example.com',
+            phone: '+255700000000',
+            // `start_date` / `salary` in the form become these columns
+            earliest_start: 'Immediately',
+            salary_expectation: '600,000',
+        });
+        expect(rows[0].answers.raw).toEqual(answers);
+    });
+
+    // Regression guard. Chaining .select() makes PostgREST run INSERT ... RETURNING,
+    // which needs a SELECT policy; job_applications deliberately has none, so the
+    // read-back is refused and Postgres reports it as
+    // "new row violates row-level security policy" — as if the insert itself failed.
+    // The mock resolves to a plain object with no .select, so a regression throws here.
+    it('does not read the row back after inserting', async () => {
+        const { result } = renderHook(() => useJobApplication(), { wrapper });
+
+        result.current.mutate({ role: 'Barista', answers });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(insert.mock.results[0].type).toBe('return');
+        expect(Object.keys(insert.mock.results[0].value)).not.toContain('select');
+    });
+
+    it('surfaces a Supabase error to the caller', async () => {
+        insert.mockResolvedValue({ error: { message: 'boom' } });
+
+        const { result } = renderHook(() => useJobApplication(), { wrapper });
+        result.current.mutate({ role: 'Barista', answers });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect(result.current.error).toMatchObject({ message: 'boom' });
+    });
+});

--- a/src/hooks/useJobApplication.ts
+++ b/src/hooks/useJobApplication.ts
@@ -36,13 +36,18 @@ export const useJobApplication = () => {
                 },
             };
 
-            const { data, error } = await supabase
+            // No .select() here. Chaining it makes PostgREST issue an
+            // INSERT ... RETURNING, which needs a SELECT policy — and this table
+            // deliberately has none (applicants may submit, nobody anonymous may
+            // read applications back). With RLS on, that read-back is refused and
+            // Postgres reports it as "new row violates row-level security policy",
+            // which looks like the insert failed when in fact only the return did.
+            const { error } = await supabase
                 .from('job_applications')
-                .insert([dbData])
-                .select();
+                .insert([dbData]);
 
             if (error) throw error;
-            return data;
+            return true;
         },
     });
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary

Two unrelated fixes that happened to surface in the same session.

### 1. Careers form was silently discarding every application

`useJobApplication` chained `.select()` onto the insert, which makes PostgREST issue an `INSERT ... RETURNING`. The read-back needs a **SELECT** policy, and `job_applications` deliberately has none — applicants may submit, but nobody anonymous may read applications back. Postgres refuses the return, rolls the whole statement back, and reports it as:

```
new row violates row-level security policy for table "job_applications"
```

which reads as though the *insert* was rejected when only the *return* was. Applicants saw "We could not send it just now" and nothing was ever stored.

Verified against the live project with an identical payload:

| Request | Result |
|---|---|
| `Prefer: return=representation` (what `.select()` sends) | `401` RLS violation |
| `Prefer: return=minimal` | **`201`** |

The database was correctly configured throughout — policy, grant, schema, and RLS all check out, and the request authenticates as `anon` as expected.

### 2. Events calendar updated to the confirmed Aug–Dec 2026 schedule

Replaces three placeholder events with the seven confirmed dates.

## Changes

- **`useJobApplication.ts`** — drop `.select()`. `onSuccess` never used the returned rows; it generates its own reference code.
- **`useJobApplication.test.tsx`** — new. Covers column mapping, error propagation, and a regression guard for this bug (verified to fail when `.select()` is reintroduced).
- **`src/test/setup.ts`** — new. Referenced by `vite.config.ts` but absent, so any `yarn test` run failed before this.
- **`SUPABASE_SETUP.md`** — documents the constraint; corrects the policy to `to anon, authenticated` to match what is deployed.
- **`EventsSection.tsx`** — seven confirmed events; optional `variant` field to distinguish the three Brew Better editions; `carols` category chip; removed the `.slice(0, 3)` cap that was hiding four of seven events; replaced `slice(0, 3)` month abbreviation, since "Agosti" became "AGO" — English "ago" on a card about an upcoming event.

## Testing

- `npx vitest run` — 3 passed
- `npx tsc --noEmit` — clean
- `npx vite build` — succeeds
- Live insert against the project returns `201`

## Notes for the reviewer

- A test row was written during verification and should be deleted: `delete from public.job_applications where full_name = 'ZZ TEST — Claude Code (delete me)';`
- A temporary `public.whoami()` diagnostic function was created during debugging and should be dropped.
- `yarn build` currently fails on this repo — corepack runs yarn 4.9.1 (berry) while the committed `yarn.lock` is v1 classic format. Pre-existing and unrelated to this PR; the build was verified with `npx vite build`. Worth resolving separately.
- The events list runs dry after 19 Dec 2026, at which point the section renders its heading above nothing. Adding an empty state is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)