### PR TITLE
Active menu highlight (sliding coffee bean) + event updates

### DIFF
--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -7,7 +7,7 @@ type HZEEvent = {
   title: string;
   variant?: string;
   dateISO: string;
-  category: string;
+  category?: string;
   venue: string;
   blurb: string;
 };
@@ -15,20 +15,19 @@ type HZEEvent = {
 // EDIT EVENTS HERE
 const EVENTS: HZEEvent[] = [
   {
-    title: "Brew Better at Home",
-    variant: "Bring Your Gadgets Edition",
-    dateISO: "2026-08-29",
-    category: "brew-class",
+    title: "Cupping",
+    variant: "Slurp & Score Edition",
+    dateISO: "2026-09-05",
     venue: "HZE Mbezi",
-    blurb: "Bring your own kit — grinder, dripper, press — and we'll dial it in together.",
+    blurb: "Taste side by side the way graders do — slurp, score, and find the cup that's yours.",
   },
   {
     title: "Brew Better at Home",
-    variant: "Class",
+    variant: "Bring Your Gadgets Edition",
     dateISO: "2026-09-19",
     category: "brew-class",
     venue: "HZE Mbezi",
-    blurb: "Pour-over, French press, and fixing your home brew — hands on.",
+    blurb: "Bring your own kit — grinder, dripper, press — and we'll dial it in together.",
   },
   {
     title: "Book Swap",
@@ -182,14 +181,14 @@ const EventsSection = () => {
                         className="text-5xl leading-none"
                         style={{ fontFamily: "var(--font-condensed)", fontWeight: 700 }}
                       >
-                        {d.getDate()}
+                        {String(d.getDate()).padStart(2, "0")}
                       </span>
                       <span className="font-sans text-xs uppercase tracking-widest mt-1">
                         {MONTH_ABBR[d.getMonth()]}
                       </span>
                     </div>
                     <div className="p-4 flex-1">
-                      <Chip category={event.category} />
+                      {event.category && <Chip category={event.category} />}
                       <h3
                         className="mt-2 uppercase text-ink text-2xl leading-none"
                         style={{ fontFamily: "var(--font-condensed)", fontWeight: 700 }}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,28 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { getRoute, navigate, scrollToAnchor, useRoute, type Route } from "../lib/router";
+import { useActiveSection } from "../hooks/useActiveSection";
 
 interface HeaderProps {
   instagramUrl?: string;
   xUrl?: string;
   logoSrc?: string;
 }
+
+// `route` entries are their own page; the rest are sections of home.
+const NAV: { name: string; href: string; route?: Route }[] = [
+  { name: "Home", href: "#home" },
+  { name: "Shop", href: "#products" },
+  { name: "Ritual", href: "#/rituals", route: "rituals" },
+  { name: "Stories", href: "#our-story" },
+  { name: "Events", href: "#events" },
+  { name: "Visit Us", href: "#contact" },
+];
+
+// Stable id per item: the route name, or the section it scrolls to.
+const keyOf = (item: (typeof NAV)[number]) => item.route ?? item.href.replace("#", "");
+
+// Scroll-spy order follows the page, not the menu.
+const SECTION_IDS = ["home", "our-story", "products", "events", "contact"];
 
 export default function Header({
   instagramUrl = "https://www.instagram.com/harakatizaenzi",
@@ -15,6 +32,14 @@ export default function Header({
   const [isScrolled, setIsScrolled] = useState(false);
   const [open, setOpen] = useState(false);
   const route = useRoute();
+  const { active: activeSection, lock } = useActiveSection(SECTION_IDS, route === "home");
+
+  // Off home the page itself is the "section"; on home the scroll position wins.
+  const activeKey = route === "home" ? activeSection : route;
+
+  const navRef = useRef<HTMLElement | null>(null);
+  const linkRefs = useRef<Record<string, HTMLAnchorElement | null>>({});
+  const [pill, setPill] = useState({ left: 0, width: 0, visible: false });
 
   useEffect(() => {
     const onScroll = () => setIsScrolled(window.scrollY > 40);
@@ -22,15 +47,30 @@ export default function Header({
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  // `route` entries are their own page; the rest are sections of home.
-  const nav: { name: string; href: string; route?: Route }[] = [
-    { name: "Home", href: "#home" },
-    { name: "Shop", href: "#products" },
-    { name: "Ritual", href: "#/rituals", route: "rituals" },
-    { name: "Stories", href: "#our-story" },
-    { name: "Events", href: "#events" },
-    { name: "Visit Us", href: "#contact" },
-  ];
+  // Slide the desktop indicator under whichever link is active.
+  useEffect(() => {
+    const update = () => {
+      const link = linkRefs.current[activeKey];
+      const wrap = navRef.current;
+      if (!link || !wrap) {
+        setPill((p) => (p.visible ? { ...p, visible: false } : p));
+        return;
+      }
+      const a = link.getBoundingClientRect();
+      const b = wrap.getBoundingClientRect();
+      setPill({ left: a.left - b.left, width: a.width, visible: true });
+    };
+
+    update();
+    // Re-measure once layout/webfonts settle — label widths shift with them.
+    const frame = requestAnimationFrame(update);
+    document.fonts?.ready.then(update).catch(() => {});
+    window.addEventListener("resize", update);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", update);
+    };
+  }, [activeKey]);
 
   const handleNav = (
     e: React.MouseEvent<HTMLAnchorElement>,
@@ -44,6 +84,8 @@ export default function Header({
       return;
     }
     const id = href.replace("#", "");
+    // Pin the highlight so it doesn't strobe through every section on the way.
+    lock(id);
     // Off the home route these sections are not mounted — go home first.
     if (getRoute() !== "home") {
       navigate("home", id);
@@ -70,21 +112,68 @@ export default function Header({
           </a>
 
           {/* Desktop nav — center */}
-          <nav className="hidden md:flex items-center gap-7 lg:gap-9">
-            {nav.map((item) => (
-              <a
-                key={item.name}
-                href={item.href}
-                onClick={(e) => handleNav(e, item.href, item.route)}
-                className={`font-sans tracking-tight transition-colors py-2 ${
-                  item.route && route === item.route
-                    ? "text-hze-red font-medium border-b-2 border-hze-red"
-                    : "text-enzi-db hover:text-coffee-gold"
-                }`}
+          <nav ref={navRef} className="hidden md:flex relative items-center gap-7 lg:gap-9">
+            {NAV.map((item) => {
+              const key = keyOf(item);
+              const isActive = key === activeKey;
+              return (
+                <a
+                  key={item.name}
+                  ref={(el) => {
+                    linkRefs.current[key] = el;
+                  }}
+                  href={item.href}
+                  onClick={(e) => handleNav(e, item.href, item.route)}
+                  aria-current={isActive ? "page" : undefined}
+                  className={`group relative font-sans tracking-tight py-2 transition-colors duration-300 ${
+                    isActive
+                      ? "text-hze-red font-medium"
+                      : "text-enzi-db hover:text-coffee-gold"
+                  }`}
+                >
+                  {item.name}
+                  {/* Hover hint — grows from the left, hidden once active. */}
+                  <span
+                    aria-hidden
+                    className={`pointer-events-none absolute -bottom-1 left-0 h-px w-full origin-left bg-coffee-gold/60 transition-transform duration-300 ${
+                      isActive ? "scale-x-0" : "scale-x-0 group-hover:scale-x-100"
+                    }`}
+                  />
+                </a>
+              );
+            })}
+
+            {/* Sliding bean — an invisible track carries it between links. */}
+            <span
+              aria-hidden
+              className="pointer-events-none absolute -bottom-0.5 left-0 h-[10px] transition-[transform,width,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
+              style={{
+                width: pill.width,
+                transform: `translateX(${pill.left}px)`,
+                opacity: pill.visible ? 1 : 0,
+              }}
+            >
+              {/* The bean itself, centred on the active link. */}
+              <svg
+                width="13"
+                height="10"
+                viewBox="0 0 13 10"
+                aria-hidden
+                className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 [filter:drop-shadow(0_1px_0.5px_rgba(58,36,21,0.55))]"
               >
-                {item.name}
-              </a>
-            ))}
+                <g transform="rotate(-20 6.5 5)">
+                  <ellipse cx="6.5" cy="5" rx="5.5" ry="2.9" fill="#3A2415" />
+                  <path
+                    d="M1.9 5.4C3.6 3.8 4.8 6.5 6.5 5s3.1-1.2 4.6.4"
+                    fill="none"
+                    stroke="#EDE5CF"
+                    strokeOpacity="0.7"
+                    strokeWidth="0.7"
+                    strokeLinecap="round"
+                  />
+                </g>
+              </svg>
+            </span>
           </nav>
 
           {/* Socials — right (desktop) + burger (mobile) */}
@@ -142,20 +231,38 @@ export default function Header({
         }`}
       >
         <nav className="mx-4 mb-3 border border-coffee-brown/20 bg-white shadow-sm">
-          {nav.map((item) => (
-            <a
-              key={item.name}
-              href={item.href}
-              onClick={(e) => handleNav(e, item.href, item.route)}
-              className={`px-6 py-4 hover:bg-coffee-brown/5 font-sans min-h-[48px] flex items-center ${
-                item.route && route === item.route
-                  ? "text-hze-red font-medium"
-                  : "text-enzi-db/90 hover:text-coffee-gold"
-              }`}
-            >
-              {item.name}
-            </a>
-          ))}
+          {NAV.map((item) => {
+            const key = keyOf(item);
+            const isActive = key === activeKey;
+            return (
+              <a
+                key={item.name}
+                href={item.href}
+                onClick={(e) => handleNav(e, item.href, item.route)}
+                aria-current={isActive ? "page" : undefined}
+                className={`relative overflow-hidden px-6 py-4 font-sans min-h-[48px] flex items-center transition-colors duration-300 ${
+                  isActive
+                    ? "text-hze-red font-medium bg-hze-red/[0.06]"
+                    : "text-enzi-db/90 hover:text-coffee-gold hover:bg-coffee-brown/5"
+                }`}
+              >
+                {/* Roast-bar that slides in on the active row. */}
+                <span
+                  aria-hidden
+                  className={`absolute left-0 top-0 h-full w-[3px] origin-top rounded-[0.5px] bg-gradient-to-b from-hze-red to-clay shadow-[1px_0_2px_rgba(58,36,21,0.25)] transition-transform duration-300 ease-out ${
+                    isActive ? "scale-y-100" : "scale-y-0"
+                  }`}
+                />
+                <span
+                  className={`transition-transform duration-300 ease-out ${
+                    isActive ? "translate-x-1.5" : "translate-x-0"
+                  }`}
+                >
+                  {item.name}
+                </span>
+              </a>
+            );
+          })}
           <div className="flex items-center gap-2 px-6 py-3 border-t border-coffee-brown/10">
             <a href={instagramUrl} target="_blank" rel="noreferrer" aria-label="Instagram" className="text-coffee-gold/90 hover:text-coffee-gold min-h-[44px] min-w-[44px] flex items-center justify-center">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Tracks which in-page section is currently under the header.
+ *
+ * A plain IntersectionObserver picks the wrong section for tall/short
+ * neighbours, so this measures against the header line instead: the active
+ * section is the last one whose top has scrolled past it.
+ *
+ * `lock(id)` pins an id while a smooth scroll is in flight — without it the
+ * highlight flickers through every section the page travels over on a click.
+ */
+export const useActiveSection = (ids: string[], enabled = true) => {
+  const [active, setActive] = useState<string>(ids[0] ?? "");
+  const lockedUntil = useRef(0);
+  const frame = useRef(0);
+
+  // ids is a fresh array each render; compare by value so the effect is stable.
+  const key = ids.join("|");
+
+  const lock = useCallback((id: string) => {
+    // Long enough to cover a smooth scroll across the page; `scrollend`
+    // releases it earlier where supported.
+    lockedUntil.current = performance.now() + 1200;
+    setActive(id);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const sectionIds = key.split("|").filter(Boolean);
+
+    const measure = () => {
+      frame.current = 0;
+      if (performance.now() < lockedUntil.current) return;
+
+      const header = document.querySelector("header");
+      const line = (header ? header.offsetHeight : 0) + 24;
+
+      // Bottom of the page: the last section can be too short to ever cross
+      // the header line, so claim it outright.
+      const atBottom =
+        window.innerHeight + window.scrollY >= document.body.scrollHeight - 4;
+
+      let current = sectionIds[0] ?? "";
+      for (const id of sectionIds) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        if (el.getBoundingClientRect().top <= line) current = id;
+        else break;
+      }
+      if (atBottom) {
+        for (let i = sectionIds.length - 1; i >= 0; i--) {
+          if (document.getElementById(sectionIds[i])) {
+            current = sectionIds[i];
+            break;
+          }
+        }
+      }
+      setActive((prev) => (prev === current ? prev : current));
+    };
+
+    const onScroll = () => {
+      if (frame.current) return;
+      frame.current = requestAnimationFrame(measure);
+    };
+
+    const onScrollEnd = () => {
+      lockedUntil.current = 0;
+      measure();
+    };
+
+    measure();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    window.addEventListener("scrollend", onScrollEnd);
+    return () => {
+      if (frame.current) cancelAnimationFrame(frame.current);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      window.removeEventListener("scrollend", onScrollEnd);
+    };
+  }, [key, enabled]);
+
+  return { active, lock };
+};


### PR DESCRIPTION
## Why

Clicking a menu item never highlighted it. Active state was only computed for route items (`item.route && route === item.route`), so the five section links — Home, Shop, Stories, Events, Visit Us — could never light up, on click or on scroll.

## What changed

**`src/hooks/useActiveSection.ts` (new)** — scroll-spy for the in-page sections:
- Picks the last section whose top crossed the header line, measured against the live header height so it stays correct at both `h-16` and `h-20`. rAF-throttled on scroll/resize.
- Claims the last section when the page bottoms out — `#contact` is too short to otherwise cross the line.
- `lock(id)` pins the highlight on click so it doesn't strobe through every section the smooth scroll travels over; released by `scrollend`, with a 1.2s fallback for Safari.

**`src/components/Header.tsx`** — one `activeKey` for both menus (the route when off home, the spied section when on it), so route items and section items highlight through the same path. Adds `aria-current="page"`.
- Desktop: a tilted coffee bean with a tight 0.5px shadow glides between links on an invisible measuring track (500ms ease-out), re-measured after webfonts load and on resize. Inactive links keep a subtle grow-from-left hover underline.
- Mobile: the active row gets a vertical roast-bar wiping in from the left, a faint tint, and the label nudging right.

**`src/components/EventsSection.tsx`** — calendar updates:
- 29 Aug → **5 Sept**, retitled **Cupping** with the subtitle *Slurp & Score Edition*, blurb rewritten to match, and no category chip.
- **19 Sept** takes over the *Bring Your Gadgets Edition* subtitle and its bring-your-kit blurb.
- Ticket stubs zero-pad single-digit dates (`05`, not `5`).

## Verification

- `npm run build` — clean
- `npx vitest run` — 3/3 pass
- `npx eslint` on the three touched files — clean (the repo has 34 pre-existing lint errors in other files, untouched here)
- `vite preview` against a fresh `dist/` — index, JS, CSS, and assets all 200

## Notes for review

- You asked for the 19th of **August**; the calendar has no August 19th and it's already past, so the subtitle went on **19 September**. Say the word if you meant a new event.
- **14 Oct** still carries `variant: "Cupping"` under a "Brew Better at Home" title — fine if cupping recurs, otherwise worth retitling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)